### PR TITLE
fix(docker): update base image to alpine/git for changelog CLI compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.22
+FROM alpine/git:2.49.1
 ARG TARGETOS
 ARG TARGETARCH
 COPY build/changelog-cli_${TARGETOS}_${TARGETARCH} /usr/local/bin/changelog-cli


### PR DESCRIPTION
Replaced the base image in the Dockerfile from alpine:3.22 to alpine/git:2.49.1. This change ensures that the changelog CLI can function correctly with the necessary Git dependencies included in the new base image.