### PR TITLE
ci: add GitHub workflows for automation and PR hygiene

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,25 @@
+---
+- name: 🚀 Feature
+  description: Feature added in the PR
+  color: F10505
+- name: 🕵🏻 Fix
+  description: Fix applied in the PR
+  color: F4D03F
+- name: ⚠️ Breaking Change
+  description: Breaking change in the PR
+  color: F1F800
+- name: 🤩 size/xs
+  description: Pull request size XS
+  color: 27AE60
+- name: 🥳 size/s
+  description: Pull request size S
+  color: 2ECC71
+- name: 😎 size/m
+  description: Pull request size M
+  color: F1C40F
+- name: 😖 size/l
+  description: Pull request size L
+  color: F39C12
+- name: 🤯 size/xl
+  description: Pull request size XL
+  color: E67E22

--- a/.github/workflows/assign-me.yml
+++ b/.github/workflows/assign-me.yml
@@ -1,0 +1,24 @@
+---
+name: 'Assign me'
+
+on:
+  pull_request:
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  set_assignee:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        if: github.actor != 'dependabot[bot]'
+        with:
+          script: |
+            github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              assignees: [context.actor],
+            })

--- a/.github/workflows/conventional-label.yml
+++ b/.github/workflows/conventional-label.yml
@@ -1,0 +1,15 @@
+---
+name: 'Conventional release labels'
+
+on:
+  pull_request_target:
+    types: [ opened, edited ]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: bcoe/conventional-release-labels@v1
+        with:
+          type_labels: '{"feat": "🚀 Feature", "fix": "🕵🏻 Fix", "breaking": "⚠️ Breaking Change"}'
+        continue-on-error: true

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -1,0 +1,48 @@
+---
+name: 'Lint PR Title'
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - labeled
+      - unlabeled
+
+permissions:
+  pull-requests: write
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        id: lint_pr_title
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          ignoreLabels: |
+            bot
+            autorelease: pending
+      - uses: marocchino/sticky-pull-request-comment@v2
+        if: always() && (steps.lint_pr_title.outputs.error_message != null)
+        with:
+          header: pr-title-lint-error
+          message: |
+            Hey mate 👋. Thank you for opening this Pull Request 🤘. It is really awesome to see this contribution 🚀
+
+            🔎 When working with this project we are requesting to follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/) and it looks like your proposed title needs to be adjusted 🥶.
+
+            👇 Below you can find details about what failed:
+
+            ```
+            ${{ steps.lint_pr_title.outputs.error_message }}
+            ```
+
+      - if: ${{ steps.lint_pr_title.outputs.error_message == null }}
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: pr-title-lint-error
+          delete: true

--- a/.github/workflows/pr-size-labeler.yml
+++ b/.github/workflows/pr-size-labeler.yml
@@ -1,0 +1,32 @@
+---
+name: 'PR Size Labeler'
+
+on:
+  pull_request:
+
+jobs:
+  labeler:
+    permissions:
+      pull-requests: write
+      contents: read
+      issues: write
+    runs-on: ubuntu-latest
+    name: Label the PR size
+    steps:
+      - uses: codelytv/pr-size-labeler@v1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          xs_label: '🤩 size/xs'
+          xs_max_size: '10'
+          s_label: '🥳 size/s'
+          s_max_size: '100'
+          m_label: '😎 size/m'
+          m_max_size: '500'
+          l_label: '😖 size/l'
+          l_max_size: '1000'
+          xl_label: '🤯 size/xl'
+          fail_if_xl: 'false'
+          message_if_xl: >
+            This PR exceeds the recommended size of 1000 lines.
+            Please make sure you are NOT addressing multiple issues with one PR.
+            Note this PR might be rejected due to its size.


### PR DESCRIPTION
- add assign-me.yml to automatically assign PRs to their authors
- add conventional-label.yml to apply semantic labels based on PR titles
- add lint-pr-title.yml to enforce Conventional Commits in PR titles
- add pr-size-labeler.yml to tag PRs based on size thresholds